### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/func/set.js
+++ b/func/set.js
@@ -46,7 +46,7 @@ function set (obj, property, value) {
       var props = helperGetHGSKeys(property)
       var len = props.length
       for (var index = 0; index < len; index++) {
-        if(isPrototypePolluted(props[index])) continue
+        if (isPrototypePolluted(props[index])) continue
         rest = valSet(rest, props[index], index === len - 1, value)
       }
     }

--- a/func/set.js
+++ b/func/set.js
@@ -46,11 +46,20 @@ function set (obj, property, value) {
       var props = helperGetHGSKeys(property)
       var len = props.length
       for (var index = 0; index < len; index++) {
+        if(isPrototypePolluted(props[index])) continue
         rest = valSet(rest, props[index], index === len - 1, value)
       }
     }
   }
   return obj
+}
+
+/**
+ * Blacklist certain keys to prevent Prototype Pollution
+ * @param {string} key
+ */
+function isPrototypePolluted(key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key)
 }
 
 module.exports = set


### PR DESCRIPTION
### :bar_chart: Metadata *

`xe-utils` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-xe-utils

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const { set } = require('xe-utils')
console.log(`Before: ${{}.polluted}`)
set({}, '__proto__.polluted', true)
console.log(`After: ${{}.polluted}`)
```
2. Execute the following commands in terminal:
```bash
npm i xe-utils # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/103890765-a84de000-510e-11eb-933f-3f0adc485ace.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
